### PR TITLE
AuthLayout fix for mobile navigation

### DIFF
--- a/src/components/Navbar/BaseNav.vue
+++ b/src/components/Navbar/BaseNav.vue
@@ -112,7 +112,9 @@ export default {
   },
   methods: {
     toggleMenu() {
-      this.$emit('change', !this.show);
+	  // this method is immediately hiding the navbar.
+	  // @change and :show is also not used by default, so this can be removed
+      //this.$emit('change', !this.show);
     },
     closeMenu() {
       this.$emit('change', false);

--- a/src/views/Pages/AuthLayout.vue
+++ b/src/views/Pages/AuthLayout.vue
@@ -22,7 +22,7 @@
              </router-link>
            </b-col>
            <b-col cols="6" class="collapse-close">
-             <button type="button" class="navbar-toggler" @click="showMenu = false">
+             <button type="button" class="navbar-toggler" @click="showMenu = false" v-b-toggle.nav-text-collapse>
                <span></span>
                <span></span>
              </button>

--- a/src/views/Pages/AuthLayout.vue
+++ b/src/views/Pages/AuthLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main-content bg-default">
     <base-nav
-	  :show="showMenu"
+      v-model="showMenu"
       :transparent="true"
       menu-classes="justify-content-end"
       class="navbar-horizontal navbar-main navbar-top navbar-dark"

--- a/src/views/Pages/AuthLayout.vue
+++ b/src/views/Pages/AuthLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="main-content bg-default">
     <base-nav
-      v-model="showMenu"
+	  :show="showMenu"
       :transparent="true"
       menu-classes="justify-content-end"
       class="navbar-horizontal navbar-main navbar-top navbar-dark"


### PR DESCRIPTION
I noticed that the navbar immediately hides after tapping the navbar icon on a mobile device. To reproduce the issue I'm describing, clone the repo, serve it, then open up the login page in Chrome and adjust the window width to a mobile width. The demo page for this repo works just fine so I wonder if this was fixed already and not pushed.

This can be fixed by using Bootstrap Vue's [v-b-toggle directive](https://bootstrap-vue.org/docs/directives/toggle) and removing the toggleMenu method in the BaseNav component.